### PR TITLE
Move content-type header and double CRLF to the end of the headers

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -81,9 +81,6 @@
 			} else {
 				$headers .= "From: " . $site_from . PHP_EOL;
 			}
-			$headers .= "X-Mailer: PHP/" . phpversion() . PHP_EOL;
-			$headers .= "MIME-Version: 1.0" . PHP_EOL;
-			$headers .= "Content-Type: multipart/alternative; boundary=\"" . $boundary . "\"" . PHP_EOL . PHP_EOL;
 
 			// check CC mail
 			if(!empty($options["cc"])){
@@ -94,6 +91,10 @@
 			if(!empty($options["bcc"])){
 				$headers .= "Bcc: " . implode(", ", $options["bcc"]) . PHP_EOL;
 			}
+
+			$headers .= "X-Mailer: PHP/" . phpversion() . PHP_EOL;
+			$headers .= "MIME-Version: 1.0" . PHP_EOL;
+			$headers .= "Content-Type: multipart/alternative; boundary=\"" . $boundary . "\"" . PHP_EOL . PHP_EOL;
 
 			// start building the message
 			$message = "";


### PR DESCRIPTION
This fixes the case that cc and bcc headers are otherwise ignored
because of the double CRLF after the content-type header.
