### PR TITLE
URLs found from notification body now get converted into formatted links

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -339,6 +339,8 @@ function html_email_handler_make_html_body($options = "", $body = "") {
 	
 	$options = array_merge($defaults, $options);
 	
+	$options['body'] = parse_urls($options['body']);
+	
 	// in some cases when pagesetup isn't done yet this can cause problems
 	// so manualy set is to done
 	$unset = false;


### PR DESCRIPTION
This was just a quick fix, so I'm not sure if it's the best way.

Let me know if you don't want to add this or want to do it differently.