### PR TITLE
vendor/autoload.php doesn't exist

### DIFF
--- a/start.php
+++ b/start.php
@@ -5,7 +5,6 @@
 
 require_once(dirname(__FILE__) . "/lib/functions.php");
 require_once(dirname(__FILE__) . "/lib/hooks.php");
-require_once(dirname(__FILE__) . "/vendor/autoload.php");
 
 // register default Elgg events
 elgg_register_event_handler("init", "system", "html_email_handler_init");


### PR DESCRIPTION
Fatal error when trying to load file vendor/autoload.php that does not exist anymore.